### PR TITLE
Add LC_ALL=C to enforce consistent ASCII sorting

### DIFF
--- a/linux/simba-setup.sh
+++ b/linux/simba-setup.sh
@@ -56,7 +56,7 @@ if [ ! -f $DESKTOP_FILE ]; then
   echo 'Type=Application' >>$DESKTOP_FILE
   echo 'Name=Simba' >>$DESKTOP_FILE
   echo 'Comment=Simba 1400' >>$DESKTOP_FILE
-  echo "Exec=$SIMBA_DIR/Simba" >>$DESKTOP_FILE
+  echo "Exec=env LC_ALL=C $SIMBA_DIR/Simba" >>$DESKTOP_FILE
   echo "Icon=$SIMBA_DIR/Simba.ico" >>$DESKTOP_FILE
   echo 'Categories=Game' >>$DESKTOP_FILE
   echo 'MimeType=text/simba;text/graph;' >>$DESKTOP_FILE


### PR DESCRIPTION
Forces basic ASCII collation instead of locale-specific sorting rules, preventing unexpected behavior from different regional character orderings. Thanks @bennyues

Solution for existing Linux users is to add `env LC_ALL=C` to `~/.local/share/applications/simba.desktop` Exec or `export setlocale(LC_ALL, 'C')` for environment.

```
# ~/.local/share/applications/simba.desktop
[Desktop Entry]
Type=Application
Name=Simba
Comment=Simba 1400
Exec=env LC_ALL=C /home/USERNAME/Simba/Simba # Inserted here
Icon=/home/USERNAME/Simba/Simba.ico
Categories=Game
MimeType=text/simba;text/graph;
Terminal=false
Keywords=Simba;RuneScape;OSRS;
``` 